### PR TITLE
Flowlogslocation

### DIFF
--- a/nsglogs.tf
+++ b/nsglogs.tf
@@ -38,7 +38,7 @@ data "azurerm_log_analytics_workspace" "main" {
 }
 
 resource "azurerm_network_watcher_flow_log" "main" {
-  count = "${var.ignore_changes}"
+  count = var.ignore_changes
   network_watcher_name = data.azurerm_network_watcher.main.name
   resource_group_name  = data.azurerm_resource_group.watcherrg.name
   name                 = "${var.spokensg}-flowlog"   

--- a/nsglogs.tf
+++ b/nsglogs.tf
@@ -38,6 +38,7 @@ data "azurerm_log_analytics_workspace" "main" {
 }
 
 resource "azurerm_network_watcher_flow_log" "main" {
+  count = "${var.ignore_changes}"
   network_watcher_name = data.azurerm_network_watcher.main.name
   resource_group_name  = data.azurerm_resource_group.watcherrg.name
   name                 = "${var.spokensg}-flowlog"   
@@ -49,7 +50,8 @@ resource "azurerm_network_watcher_flow_log" "main" {
   enabled                   = true
   lifecycle { 
     ignore_changes = [
-      tags
+      tags,
+      location
    ] 
  }
 
@@ -66,4 +68,3 @@ resource "azurerm_network_watcher_flow_log" "main" {
     interval_in_minutes   = 60
   }
 }
-

--- a/nsglogs.tf
+++ b/nsglogs.tf
@@ -38,7 +38,7 @@ data "azurerm_log_analytics_workspace" "main" {
 }
 
 resource "azurerm_network_watcher_flow_log" "main" {
-  #count = "${var.ignore_changes}"
+  count = "${var.ignore_changes}"
   network_watcher_name = data.azurerm_network_watcher.main.name
   resource_group_name  = data.azurerm_resource_group.watcherrg.name
   name                 = "${var.spokensg}-flowlog"   

--- a/nsglogs.tf
+++ b/nsglogs.tf
@@ -38,7 +38,7 @@ data "azurerm_log_analytics_workspace" "main" {
 }
 
 resource "azurerm_network_watcher_flow_log" "main" {
-  count = "${var.ignore_changes}"
+  #count = "${var.ignore_changes}"
   network_watcher_name = data.azurerm_network_watcher.main.name
   resource_group_name  = data.azurerm_resource_group.watcherrg.name
   name                 = "${var.spokensg}-flowlog"   

--- a/variables.tf
+++ b/variables.tf
@@ -3,11 +3,11 @@ variable "rg" {
     default = ""
 }
 
-#variable "ignore_changes" {
-#  type        = number
-#  description = "Choose whether to create a version that uses hardcoded ignore_changes"
-#  default     = 1
-#}
+variable "ignore_changes" {
+  type        = number
+  description = "Choose whether to create a version that uses hardcoded ignore_changes"
+  default     = 1
+}
 
 variable "watcherrg" {
     description = "rg for NetworkWatcher"

--- a/variables.tf
+++ b/variables.tf
@@ -3,6 +3,12 @@ variable "rg" {
     default = ""
 }
 
+variable "ignore_changes" {
+  type        = number
+  description = "Choose whether to create a version that uses hardcoded ignore_changes"
+  default     = 1
+}
+
 variable "watcherrg" {
     description = "rg for NetworkWatcher"
     default = "NetworkWatcherRG"

--- a/variables.tf
+++ b/variables.tf
@@ -3,11 +3,11 @@ variable "rg" {
     default = ""
 }
 
-variable "ignore_changes" {
-  type        = number
-  description = "Choose whether to create a version that uses hardcoded ignore_changes"
-  default     = 1
-}
+#variable "ignore_changes" {
+#  type        = number
+#  description = "Choose whether to create a version that uses hardcoded ignore_changes"
+#  default     = 1
+#}
 
 variable "watcherrg" {
     description = "rg for NetworkWatcher"


### PR DESCRIPTION
* Added in count to network watcher flow logs and vars.tf 
* This is a workaround for the constant replacement  for flow logs when ever spokes are run. 
Not picking up the location as it should and wants to replace/destroy resource. This could be a bug reading a data source value. 
