### PR TITLE
Update nsglogs.tf for fixing the warning

### DIFF
--- a/nsglogs.tf
+++ b/nsglogs.tf
@@ -45,7 +45,7 @@ resource "azurerm_network_watcher_flow_log" "main" {
   provider             = azurerm.nsgflow
   version              = "2"
 
-  network_security_group_id = data.azurerm_network_security_group.main.id
+  target_resource_id        = data.azurerm_network_security_group.main.id
   storage_account_id        = data.azurerm_storage_account.main.id
   enabled                   = true
   lifecycle { 


### PR DESCRIPTION
Updated the property from network_security_group_id to target_resource_id.  
Fix for :  The property `network_security_group_id` has been superseded by `target_resource_id` and will be removed in version 5.0 of the AzureRM Provider.